### PR TITLE
Drop support for rand_core < 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+* Update `rand_core` dependency to exactly `0.6`, dropping support for `rand_core <= 0.5`. This
+  works around Cargo issues where unrelated updates can cause the `rand_core` dependency to "snap
+  back" to older versions.
+
 ## [0.2.3] - 2022-02-24
 Fix undefined behaviour caused by narrowing provenance of slice pointer to a
 single element then reading multiple elements (#8).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.3.0] - 2024-07-31
 
 * Update `rand_core` dependency to exactly `0.6`, dropping support for `rand_core <= 0.5`. This
   works around Cargo issues where unrelated updates can cause the `rand_core` dependency to "snap

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_seeder"
-version = "0.2.3" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.3.0" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ keywords = ["random", "rng", "seeder"]
 categories = ["algorithms", "no-std"]
 
 [dependencies]
-rand_core = { version = ">= 0.1, <= 0.6", default-features = false }
+rand_core = { version = "0.6", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/rand_seeder/0.2.3"
+    html_root_url = "https://docs.rs/rand_seeder/0.3.0"
 )]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
This works around a Cargo issue where unrelated updates can cause the `rand_core` dependency to "snap back" to older versions.

Fixes #9.